### PR TITLE
Hotfix/v1.0.2

### DIFF
--- a/__tests__/runtime/models/survey/BranchDefinition_spec.js
+++ b/__tests__/runtime/models/survey/BranchDefinition_spec.js
@@ -191,8 +191,9 @@ describe('BranchDefinition', () => {
 
   describe('updateChildConditionAttribute', () => {
     it('childConditionの属性を更新できる', () => {
-      const result = state.getSurvey().findBranch('805905f0-ef30-4a7c-949b-4f1e6f48f212')
-        .updateChildConditionAttribute('f538b3df-ecd7-486e-921c-a2a497ee9d09', '57ea60ac-a7c9-48c8-a552-eb4940f7060c', 'operator', '!=');
+      const survey = state.getSurvey();
+      const result = survey.findBranch('805905f0-ef30-4a7c-949b-4f1e6f48f212')
+        .updateChildConditionAttribute(survey, 'f538b3df-ecd7-486e-921c-a2a497ee9d09', '57ea60ac-a7c9-48c8-a552-eb4940f7060c', 'operator', '!=');
       expect(result.getIn(['conditions', 0, 'childConditions', 0, 'operator'])).toBe('!=');
     });
   });

--- a/lib/editor/components/Editor.js
+++ b/lib/editor/components/Editor.js
@@ -16,10 +16,9 @@ class Editor extends Component {
     window.addEventListener('beforeunload', (e) => {
       const { view } = this.props;
       const saveSurveyStatus = view.getSaveSurveyStatus();
-      if (saveSurveyStatus === SURVEY_NOT_MODIFIED || saveSurveyStatus === SURVEY_POSTED_SUCCESS) return null;
-      const message = '修正が保存されていませんがこのページから遷移しますか？';
-      e.returnValue = message;
-      return message;
+      if (!(saveSurveyStatus === SURVEY_NOT_MODIFIED || saveSurveyStatus === SURVEY_POSTED_SUCCESS)) {
+        e.returnValue = '修正が保存されていませんがこのページから遷移しますか？';
+      }
     }, false);
   }
 

--- a/lib/editor/components/Menu.js
+++ b/lib/editor/components/Menu.js
@@ -150,7 +150,7 @@ class Menu extends Component {
               <Glyphicon glyph="ok" className={classNames({ invisible: !showPreviewPane })} /> プレビュー
             </MenuItem>
           </NavDropdown>
-          <NavItem className="menu-validation" onClick={() => this.handleValidation()}>バリデーション</NavItem>
+          <NavItem className="menu-validation" onClick={() => this.handleValidation()}>検証</NavItem>
           <NavDropdown className="menu-preview" eventKey={1} title="プレビュー" id="basic-nav-dropdown">
             <MenuItem eventKey={1.1} className="menu-dynamic-preview" href="#" onClick={() => this.handleClickPreview()}>動作プレビュー</MenuItem>
             <MenuItem eventKey={1.1} className="menu-detail-preview" href="#" onClick={() => this.handleClickShowDetail()}>詳細プレビュー</MenuItem>

--- a/lib/editor/components/editors/ConditionEditor.js
+++ b/lib/editor/components/editors/ConditionEditor.js
@@ -118,8 +118,8 @@ class ConditionEditor extends Component {
             onChange={e => this.handleChangeChildCondition(childCondition.getId(), 'value', e.target.value)}
             detailMode={options.isShowDetail()}
           >
-            <option value="">選択していない</option>
-            <option value="1">選択している</option>
+            <option value="false">選択していない</option>
+            <option value="true">選択している</option>
           </ExSelect>),
         ];
       case 'select':

--- a/lib/editor/containers/EnqueteEditorApp.js
+++ b/lib/editor/containers/EnqueteEditorApp.js
@@ -56,7 +56,7 @@ class EnqueteEditorApp extends Component {
           </html>`}
           mountTarget="#runtime-container"
         >
-          <EnqueteRuntimeApp doNotPostAnswers doNotTransition doNotExecuteJavaScript />
+          <EnqueteRuntimeApp doNotPostAnswers doNotTransition doNotExecuteJavaScript doNotValidate />
         </Frame>
       </div>
     );

--- a/lib/editor/css/editor.scss
+++ b/lib/editor/css/editor.scss
@@ -498,6 +498,22 @@ html, body {
   border-left: 0;
   border-right: 0;
 
+  .menu-title {
+    white-space: nowrap;
+    > * {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      max-width: 450px;
+    }
+  }
+  .menu-panel {
+    white-space: nowrap;
+    > * {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      max-width: 330px;
+    }
+  }
   &-nav {
 
     &__left {

--- a/lib/editor/reducers.js
+++ b/lib/editor/reducers.js
@@ -89,7 +89,7 @@ function branchReducer(survey, action) {
       return survey.updateIn(branchSelector(survey, action), branch =>
         branch.updateConditionAttribute(action.conditionId, action.attributeName, action.value));
     case C.CHANGE_CHILD_CONDITION_ATTRIBUTE:
-      return survey.updateIn(branchSelector(survey, action), branch => branch.updateChildConditionAttribute(action.conditionId,
+      return survey.updateIn(branchSelector(survey, action), branch => branch.updateChildConditionAttribute(survey, action.conditionId,
         action.childConditionId, action.attributeName, action.value));
     case C.REMOVE_CHILD_CONDITION:
       return survey.updateIn(branchSelector(survey, action), branch =>

--- a/lib/runtime/components/Page.js
+++ b/lib/runtime/components/Page.js
@@ -60,16 +60,21 @@ class Page extends Component {
     // ユーザの入力値
     formElements.forEach((el) => {
       if (S(el.name).isEmpty()) return; // name属性が定義されていない場合は値を格納しない
-      if ($(el).is(':hidden')) return; // 要素が表示されていない場合は値を格納しない
       if (el.type === 'checkbox') {
+        if ($(el).is(':hidden')) return; // 要素が表示されていない場合は値を格納しない
         if (answers[el.name] !== undefined) throw new Error(`タグのname属性が重複しています。name: ${el.name}`);
         answers[el.name] = el.checked ? el.value : 0;
       } else if (el.type === 'radio') {
+        if ($(el).is(':hidden')) return; // 要素が表示されていない場合は値を格納しない
         if (el.disabled) return; // disabledの場合は値を格納しない
         if (!el.checked) return; // 選択されていない項目の値は格納しない
         if (answers[el.name] !== undefined) throw new Error(`タグのname属性が重複しています。name: ${el.name}`);
         answers[el.name] = el.value;
+      } else if (el.type === 'hidden') {
+        // hiddenの場合は条件なしに登録する
+        answers[el.name] = el.value;
       } else {
+        if ($(el).is(':hidden')) return; // 要素が表示されていない場合は値を格納しない
         if (el.disabled) return; // disabledの場合は値を格納しない
         if (answers[el.name] !== undefined) throw new Error(`タグのname属性が重複しています。name: ${el.name}`);
         answers[el.name] = el.value;

--- a/lib/runtime/components/Page.js
+++ b/lib/runtime/components/Page.js
@@ -127,7 +127,8 @@ class Page extends Component {
   }
 
   parsley() {
-    const { options } = this.props;
+    const { options, doNotValidate } = this.props;
+    if (doNotValidate) return;
     // showDetailのときはparsleyを有効にしない
     if (options.isShowDetail()) return;
     this.$parsley = $(this.pageEl).parsley();

--- a/lib/runtime/components/Page.js
+++ b/lib/runtime/components/Page.js
@@ -60,15 +60,17 @@ class Page extends Component {
     // ユーザの入力値
     formElements.forEach((el) => {
       if (S(el.name).isEmpty()) return; // name属性が定義されていない場合は値を格納しない
-      if (el.disabled) return; // disabledの場合は値を格納しない
+      if ($(el).is(':hidden')) return; // 要素が表示されていない場合は値を格納しない
       if (el.type === 'checkbox') {
         if (answers[el.name] !== undefined) throw new Error(`タグのname属性が重複しています。name: ${el.name}`);
-        answers[el.name] = el.checked ? el.value : '';
+        answers[el.name] = el.checked ? el.value : 0;
       } else if (el.type === 'radio') {
+        if (el.disabled) return; // disabledの場合は値を格納しない
         if (!el.checked) return; // 選択されていない項目の値は格納しない
         if (answers[el.name] !== undefined) throw new Error(`タグのname属性が重複しています。name: ${el.name}`);
         answers[el.name] = el.value;
       } else {
+        if (el.disabled) return; // disabledの場合は値を格納しない
         if (answers[el.name] !== undefined) throw new Error(`タグのname属性が重複しています。name: ${el.name}`);
         answers[el.name] = el.value;
       }

--- a/lib/runtime/components/questions/ChoiceQuestionBase.js
+++ b/lib/runtime/components/questions/ChoiceQuestionBase.js
@@ -72,7 +72,7 @@ export default class ChoiceQuestionBase extends TransformQuestion {
  */
 class Item extends Component {
   /** addtionalInputを描画する */
-  static renderAdditionalInput(itemState, item, question) {
+  static renderAdditionalInput(itemState, item, question, errorContainerId) {
     if (!item.hasAdditionalInput()) return null;
     const type = item.getAdditionalInputType();
     const disabled = !itemState.get('checked');
@@ -82,6 +82,7 @@ class Item extends Component {
         pattern={type === 'number' ? '\\d*' : null}
         maxLength={type === 'number' ? 16 : 100}
         name={question.getOutputName(item.getIndex(), true)}
+        data-parsley-errors-container={`#${errorContainerId}`}
         data-parsley-required
         data-parsley-type={type === 'number' ? 'digits' : null}
         data-parsley-type-message="半角数字のみで入力してください"
@@ -113,13 +114,15 @@ class Item extends Component {
     const value = item.getValue();
     const dataType = question.getDataType();
     const showItemDetail = options.isShowDetail() && (item.isRandomFixed() || item.isExclusive());
+    const name = question.getOutputName(item.getIndex(), false);
+    const errorContainerId = `${name}_error_container`;
     return (
       <li className={className}>
         <label className={classNames('question-form-list-label', { 'detail-shown': showItemDetail })}>
           <input
             className="question-form-list-input"
             type={inputType}
-            name={question.getOutputName(item.getIndex(), false)}
+            name={name}
             value={value}
             checked={itemState.get('checked')}
             onChange={handleItemCheckedChange}
@@ -135,9 +138,10 @@ class Item extends Component {
             data-parsley-multiple={question.getId()}
           />
           <span dangerouslySetInnerHTML={{ __html: replacer.id2Value(label) }} />
-          {Item.renderAdditionalInput(itemState, item, question)}
+          {Item.renderAdditionalInput(itemState, item, question, errorContainerId)}
           <span dangerouslySetInnerHTML={{ __html: replacer.id2Value(unit) }} />
           {this.createItemDetail()}
+          <span id={errorContainerId} />
         </label>
       </li>
     );

--- a/lib/runtime/components/questions/MultiNumberQuestion.js
+++ b/lib/runtime/components/questions/MultiNumberQuestion.js
@@ -49,6 +49,7 @@ class MultiNumberQuestion extends TransformQuestion {
     const { replacer, question } = this.props;
     const name = question.getOutputName(isTotal, item.getIndex());
     const totalEqualTo = question.getTotalEqualTo();
+    const errorContainerId = `${name}_error_container`;
     return (
       <div ref={(el) => { this.rootEl = el; }} key={`${question.getId()}_${item.getIndex()}`} className={classNames('multiNumberLine', { multiNumberTotal: isTotal })}>
         <div className="multiNumberLabel">
@@ -71,8 +72,10 @@ class MultiNumberQuestion extends TransformQuestion {
               data-parsley-min={isTotal || S(question.getMin()).isEmpty() ? null : replacer.id2Value(question.getMin())}
               data-parsley-max={isTotal || S(question.getMax()).isEmpty() ? null : replacer.id2Value(question.getMax())}
               data-parsley-equal={isTotal && !S(totalEqualTo).isEmpty() ? replacer.id2Value(totalEqualTo) : null}
+              data-parsley-errors-container={`#${errorContainerId}`}
             />
             <span className="multiNumberUnit"> {question.getUnit()}</span>
+            <span id={errorContainerId} />
           </div>
         </div>
         {this.createItemDetail(item)}

--- a/lib/runtime/containers/EnqueteRuntimeApp.js
+++ b/lib/runtime/containers/EnqueteRuntimeApp.js
@@ -36,6 +36,7 @@ class EnqueteRuntimeApp extends Component {
        doNotPostAnswers,
        doNotTransition,
        doNotExecuteJavaScript,
+       doNotValidate,
        showEditModeMessage,
        showAnswerDownloadLink,
      } = this.props;
@@ -49,6 +50,7 @@ class EnqueteRuntimeApp extends Component {
           page={runtime.findCurrentPage(survey)}
           doNotTransition={doNotTransition}
           doNotExecuteJavaScript={doNotExecuteJavaScript}
+          doNotValidate={doNotValidate}
           showEditModeMessage={showEditModeMessage}
         />
       );

--- a/lib/runtime/css/common.scss
+++ b/lib/runtime/css/common.scss
@@ -40,6 +40,9 @@ $number-input-width: 4em;
   padding: 1px 7px;
   margin: 0 3px;
   white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 250px;
+  overflow: hidden;
 }
 
 .detail-function {

--- a/lib/runtime/models/survey/BranchDefinition.js
+++ b/lib/runtime/models/survey/BranchDefinition.js
@@ -22,11 +22,14 @@ export default class BranchDefinition extends BranchDefinitionRecord {
   static createEvaluateChildConditionClosure(answers, allOutputDefinitionsMap, replacer) {
     return (childCondition) => {
       const od = allOutputDefinitionsMap.get(childCondition.getOutputId());
-      const answerValue = S(answers.get(od.getName())).s;
+      const rawAnswerValue = answers.get(od.getName());
+      const answerValue = S(rawAnswerValue).s;
       const op = childCondition.getOperator();
       const value = S(replacer.id2Value(childCondition.getValue())).s;
 
       switch (op) {
+        case '!!': // trueまたはfalseか。undefined, null, 0, ""の場合にはfalseになる
+          return (!!rawAnswerValue).toString() === value;
         case '==':
           return answerValue === value;
         case '!=':
@@ -131,15 +134,19 @@ export default class BranchDefinition extends BranchDefinitionRecord {
   }
 
   /** conditionの属性の更新 */
-  updateChildConditionAttribute(conditionId, childConditionId, attributeName, value) {
+  updateChildConditionAttribute(survey, conditionId, childConditionId, attributeName, value) {
     const conditionIndex = this.findConditionIndex(conditionId);
     const condition = this.getConditions().get(conditionIndex);
     const childConditionIndex = condition.findChildConditionIndex(childConditionId);
     const newState = this.setIn(['conditions', conditionIndex, 'childConditions', childConditionIndex, attributeName], value);
     if (attributeName === 'outputId') {
+      const targetOutputDefinition = survey.findOutputDefinition(value);
+      // checkboxの場合にはoperatorを"!!"にする。
+      const newOperator = targetOutputDefinition.getOutputType() === 'checkbox' ? '!!' : '==';
+      const newValue = targetOutputDefinition.getOutputType() === 'checkbox' ? 'true' : '';
       return newState
-        .setIn(['conditions', conditionIndex, 'childConditions', childConditionIndex, 'operator'], '==')
-        .setIn(['conditions', conditionIndex, 'childConditions', childConditionIndex, 'value'], '');
+        .setIn(['conditions', conditionIndex, 'childConditions', childConditionIndex, 'operator'], newOperator)
+        .setIn(['conditions', conditionIndex, 'childConditions', childConditionIndex, 'value'], newValue);
     }
     return newState;
   }

--- a/lib/runtime/models/survey/PageDefinition.js
+++ b/lib/runtime/models/survey/PageDefinition.js
@@ -18,7 +18,7 @@ const PageDefinitionRecord = Record({
 export default class PageDefinition extends PageDefinitionRecord {
   static create() {
     const id = cuid();
-    const questions = List().push(CheckboxQuestionDefinition.create());
+    const questions = List().push();
     const logicalVariables = List();
     return new PageDefinition({ _id: id, questions, logicalVariables });
   }

--- a/lib/runtime/models/survey/SurveyDefinition.js
+++ b/lib/runtime/models/survey/SurveyDefinition.js
@@ -147,6 +147,11 @@ export default class SurveyDefinition extends SurveyDefinitionRecord {
       page.getQuestions().find(question => question.getId() === questionId) !== undefined);
   }
 
+  /** OutputDefinitionをIDから探す */
+  findOutputDefinition(outputDefinitionId) {
+    return this.getAllOutputDefinitions().find(od => od.getId() === outputDefinitionId);
+  }
+
   // ------------------------- calc -----------------------------
   /** pageIdに対応するページ番号を生成する */
   calcPageNo(pageId) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "Survey system using react.js",
   "scripts": {
-    "start": "node server.js",
+    "start": "NODE_ENV=development node server.js",
     "build": "webpack",
     "build:production": "NODE_ENV=production webpack",
     "build:watch": "webpack --watch",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,20 @@ const path = require('path');
 const webpack = require('webpack');
 const loadenv = require('node-env-file');
 
+const plugins = [
+  // 環境変数の読み込み
+  new webpack.DefinePlugin({
+    ENV: (() => JSON.stringify(loadenv('./.env')))(),
+    'process.env': {
+      NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+    },
+  }),
+];
+// プロダクション環境のみuglifyする
+if (process.env.NODE_ENV === 'production') {
+  plugins.push(new webpack.optimize.UglifyJsPlugin());
+}
+
 module.exports = {
   // devtool: 'cheap-module-eval-source-map',
   // devtool: 'inline-source-map',
@@ -19,16 +33,7 @@ module.exports = {
     library: 'SurveyDesigner',
     libraryTarget: 'var',
   },
-  plugins: [
-    // 環境変数の読み込み
-    new webpack.DefinePlugin({
-      ENV: (() => JSON.stringify(loadenv('./.env')))(),
-      'process.env': {
-        NODE_ENV: JSON.stringify(process.env.NODE_ENV)
-      },
-    }),
-    new webpack.optimize.UglifyJsPlugin(),
-  ],
+  plugins,
   externals: [
     { tinymce: true },
   ],


### PR DESCRIPTION
# 問題1
排他を含む選択肢を分岐条件に含むと正しく遷移しないことがある

1-1の複数選択肢を下記のように作成する

1. 分岐条件となる選択肢
2. 排他条件となる選択肢

その次に分岐条件を設定する

1-1-1 「分岐条件となる選択肢」を選択していない

この状態で、プレビュー画面を表示し、「排他条件となる選択肢」を選択して次に進むと分岐条件にマッチしない。

# 修正内容
 * チェックボックスがdisabledになっているときに、回答値が登録されないことが問題だったため、disabledでも回答値を登録するように修正
 * 分岐条件に選択した値がtrueかfalseかを比較するための演算子を追加
 * また、チェックボックスの回答値を下記のように変更。
   * 選択：1
   * 非選択：0
   * 表示されていない：空
 * ダウンロード時にも上記の値が落ちてくるようになります。

# 問題2
詳細プレビューで設問名が長いと表示が崩れる。

# 修正内容
設問名が長い場合にはtext-overflow: ellipsisを設定することで、途中で打ち切るように変更。