### PR TITLE
表形式チェックボックスの排他条件が正しく動作しない不具合に対応

### DIFF
--- a/__tests__/runtime/models/states/CheckboxQuestionState_spec.js
+++ b/__tests__/runtime/models/states/CheckboxQuestionState_spec.js
@@ -6,7 +6,7 @@ import CheckboxQuestionDefinition from '../../../../lib/runtime/models/survey/qu
 
 describe('CheckboxQuestionState', () => {
   describe('setItemState', () => {
-    it('排他を選択したときに他の項目が未選択かつdisabledになる', () => {
+    it('排他を選択したときに他の項目が選択値が変わらずdisabledになる', () => {
       const question = CheckboxQuestionDefinition
         .create()
         .set('items', List([
@@ -20,7 +20,7 @@ describe('CheckboxQuestionState', () => {
       expect(model.getIn(['itemState', 1, 'disabled'])).toBe(false);
 
       const result = model.setItemState(1, true);
-      expect(result.getIn(['itemState', 0, 'checked'])).toBe(false);
+      expect(result.getIn(['itemState', 0, 'checked'])).toBe(true);
       expect(result.getIn(['itemState', 0, 'disabled'])).toBe(true);
       expect(result.getIn(['itemState', 1, 'checked'])).toBe(true);
       expect(result.getIn(['itemState', 1, 'disabled'])).toBe(false);

--- a/lib/plainComponents.js
+++ b/lib/plainComponents.js
@@ -112,10 +112,30 @@ function attachMatrixAdditionalInput(el) {
  * グルーピングの方向はtableにsdj-group-rowsまたはsdj-group-columnsを付与する
  */
 function attachMatrixExclusiveCheckbox(el) {
+  // この関数内の2箇所で使うため敢えてここで関数を定義
+  // 入力値に応じてチェックボックスとadditional-inputのdisabledを切り替える
+  function toggleChekboxAndAdditionalInput(event, checkboxEl) {
+    if (checkboxEl === event.target) return;
+    const checked = $(event.target).prop('checked');
+    // 排他のチェックボックスをチェックした場合
+    if (checked) {
+      // checkboxElとadditional-inputをまとめて取得するためparentsを一度取得してからinputを検索する
+      $(checkboxEl).parents('td').find('input').disable(true);
+    } else {
+      const checkboxChecked = $(checkboxEl).prop('checked');
+      if (checkboxChecked) {
+        // 該当するセルのチェックボックスがチェックされているため、checkboxElとadditional-inputをまとめてdisabledを解除する
+        $(checkboxEl).parents('td').find('input').disable(false);
+      } else {
+        // 該当するセルのチェックボックスがチェックされていないため、checkboxElのみdisabledを解除する
+        $(checkboxEl).disable(false);
+      }
+    }
+  }
+
   $(el).on('change', 'table.sdj-matrix input[type="checkbox"].exclusive', (e) => {
     const $target = $(e.target);
     const $targetTable = $target.parents('table');
-    const checked = $target.prop('checked');
     const $targetTbody = $target.parents('tbody');
     const $targetTr = $target.parents('tr');
     const $targetTd = $target.parents('td');
@@ -123,15 +143,13 @@ function attachMatrixExclusiveCheckbox(el) {
     // 行でグルーピングしている場合
     if ($targetTable.hasClass('sdj-group-rows')) {
       $targetTr.find('input[type="checkbox"]').each((i, checkboxEl) => {
-        if (checkboxEl === e.target) return;
-        $(checkboxEl).disable(checked);
+        toggleChekboxAndAdditionalInput(e, checkboxEl);
       });
     // 列でグルーピングしている場合
     } else if ($targetTable.hasClass('sdj-group-columns')) {
       const index = $targetTr.find('td').index($targetTd);
       $targetTbody.find(`td:nth-child(${index + 1}) input[type="checkbox"]`).each((i, checkboxEl) => {
-        if (checkboxEl === e.target) return;
-        $(checkboxEl).disable(checked);
+        toggleChekboxAndAdditionalInput(e, checkboxEl);
       });
     } else {
       throw new Error('sdj-group-rowsまたはsdj-group-columnsがtableに指定されていません');

--- a/lib/plainComponents.js
+++ b/lib/plainComponents.js
@@ -117,18 +117,19 @@ function attachMatrixExclusiveCheckbox(el) {
   function toggleChekboxAndAdditionalInput(event, checkboxEl) {
     if (checkboxEl === event.target) return;
     const checked = $(event.target).prop('checked');
+
     // 排他のチェックボックスをチェックした場合
     if (checked) {
       // checkboxElとadditional-inputをまとめて取得するためparentsを一度取得してからinputを検索する
       $(checkboxEl).parents('td').find('input').disable(true);
     } else {
+      // まずcheckboxElをdisable解除
+      $(checkboxEl).disable(false);
+
+      // checkboxElがcheckされている場合、additional-inputもdisable解除
       const checkboxChecked = $(checkboxEl).prop('checked');
       if (checkboxChecked) {
-        // 該当するセルのチェックボックスがチェックされているため、checkboxElとadditional-inputをまとめてdisabledを解除する
-        $(checkboxEl).parents('td').find('input').disable(false);
-      } else {
-        // 該当するセルのチェックボックスがチェックされていないため、checkboxElのみdisabledを解除する
-        $(checkboxEl).disable(false);
+        $(checkboxEl).parents('td').find('input.additional-input').disable(false);
       }
     }
   }

--- a/lib/runtime/components/Page.js
+++ b/lib/runtime/components/Page.js
@@ -65,8 +65,12 @@ class Page extends Component {
       if (S(el.name).isEmpty()) return; // name属性が定義されていない場合は値を格納しない
       if (el.type === 'checkbox') {
         if ($(el).is(':hidden')) return; // 要素が表示されていない場合は値を格納しない
-        if (answers[el.name] !== undefined) throw new Error(`タグのname属性が重複しています。name: ${el.name}`);
-        answers[el.name] = el.checked ? el.value : 0;
+        if (el.disabled) { // disabledの場合はチェックしていないとみなす
+          answers[el.name] = 0;
+        } else {
+          if (answers[el.name] !== undefined) throw new Error(`タグのname属性が重複しています。name: ${el.name}`);
+          answers[el.name] = el.checked ? el.value : 0;
+        }
       } else if (el.type === 'radio') {
         if ($(el).is(':hidden')) return; // 要素が表示されていない場合は値を格納しない
         if (el.disabled) return; // disabledの場合は値を格納しない

--- a/lib/runtime/components/questions/ChoiceQuestionBase.js
+++ b/lib/runtime/components/questions/ChoiceQuestionBase.js
@@ -78,7 +78,7 @@ class Item extends Component {
     if (!item.hasAdditionalInput()) return null;
     const { survey } = this.props;
     const type = item.getAdditionalInputType();
-    const disabled = !itemState.get('checked');
+    const disabled = !itemState.get('checked') || itemState.get('disabled');
     const name = question.getOutputName(item.getIndex(), true);
 
     return (

--- a/lib/runtime/states/CheckboxQuestionState.js
+++ b/lib/runtime/states/CheckboxQuestionState.js
@@ -15,24 +15,38 @@ export default class CheckboxQuestionState extends BaseTransformedQuestionState 
     if (!item.isExclusive()) {
       return this.setIn(['itemState', index, 'checked'], checked);
     }
-    // disabledも合わせて設定することに注意
+    // 排他選択肢をcheckした場合
     if (checked) {
       return this
         .updateIn(['itemState'], state =>
-          state.map((v, i) =>
-            v
-              .set('disabled', i !== index)
-              .set('checked', i === index),
-          ),
+          state.map((v, i) => {
+            if (i === index) {
+              // 選択した排他選択肢はdisabledとcheckedを更新
+              return v
+                .set('disabled', false)
+                .set('checked', true);
+            }
+            // 選択した排他選択肢ではない場合はdisabledを更新
+            return v
+              .set('disabled', true);
+          }),
         );
     }
+
+    // 排他選択肢のチェックを外した場合
     return this
       .updateIn(['itemState'], state =>
-        state.map(v =>
-          v
-            .set('disabled', false)
-            .set('checked', false),
-        ),
+        state.map((v, i) => {
+          if (i === index) {
+            // 選択を外した排他選択肢はdisabledとcheckedを更新
+            return v
+              .set('disabled', false)
+              .set('checked', false);
+          }
+          // 選択を外した排他選択肢ではない場合はdisabledを更新
+          return v
+            .set('disabled', false);
+        }),
       );
   }
 }


### PR DESCRIPTION
修正内容

* チェックされたチェックボックスの内容がdisabledでも1として登録される不具合の修正
* 表形式の追加入力のdisabledが排他の制御から漏れていた不具合に対応
* 複数選択設問の排他の挙動を表形式チェックボックスの挙動に合わせた

### 複数選択設問の以前の挙動
排他をクリックすると、すでにチェックされていたチェックボックスのチェックが外れ、disabledになる

### 複数選択設問の今回の挙動
排他をクリックすると、すでにチェックされていたチェックボックスのチェックはそのままに、disabledになる

### 回答データ
disabledになっているチェックボックスの値は0として回答登録される。

### 参考：回答の登録データ
チェックボックスの回答データ

|                            | 表示されている|表示されていない| 表示されている and (disabled or readonly) |
| -------------      |--------------|-----------------|------------------------------------------|
|チェックされている場合| 1                       |           undefined | 0                                       |
|チェックされていない場合| 0                       |           undefined | 0                                       |
