### PR TITLE
数値に0始まりの入力が可能である不具合に対応

### DIFF
--- a/lib/ParsleyWrapper.js
+++ b/lib/ParsleyWrapper.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import Parsley from 'parsleyjs';
-import { isSP } from './utils';
+import { isSP, parseInteger } from './utils';
 
 const ERROR_CLASS = 'err';
 
@@ -106,6 +106,14 @@ export default class ParsleyWrapper {
       validateNumber: (value, requirement) => value === requirement,
       messages: {
         ja: '%sになるように入力してください',
+      },
+    });
+
+    Parsley.addValidator('positiveInteger', {
+      requirementType: 'digits',
+      validateString: value => parseInteger(value).toString() === value && parseInteger(value) >= 0,
+      messages: {
+        ja: '不正な数値形式です',
       },
     });
   }

--- a/lib/runtime/components/questions/ChoiceQuestionBase.js
+++ b/lib/runtime/components/questions/ChoiceQuestionBase.js
@@ -92,8 +92,7 @@ class Item extends Component {
           data-parsley-errors-container={`#${errorContainerId}`}
           data-output-no={survey.findOutputNoFromName(name)}
           data-parsley-required
-          data-parsley-type={type === 'number' ? 'digits' : null}
-          data-parsley-type-message="半角数字のみで入力してください"
+          data-parsley-positive-integer={type === 'number' ? true : null}
           disabled={disabled}
           className={classNames('additionalInput', { disabled, number: type === 'number' })}
           onClick={e => e.preventDefault()}

--- a/lib/runtime/components/questions/MatrixQuestion.js
+++ b/lib/runtime/components/questions/MatrixQuestion.js
@@ -41,7 +41,7 @@ class MatrixQuestion extends TransformQuestion {
           data-parsley-errors-container={`#${errorsContainerId}`}
           data-parsley-required
           data-parsley-required-message={requiredMessage}
-          data-parsley-type={inputType === 'number' ? 'digits' : null}
+          data-parsley-positive-integer={inputType === 'number' ? true : null}
         />
         {targetItem.getUnit()}
         <span id={errorsContainerId} />
@@ -97,7 +97,7 @@ class MatrixQuestion extends TransformQuestion {
             size="4"
             data-output-no={survey.findOutputNoFromName(name)}
             data-parsley-required
-            data-parsley-type="digits"
+            data-parsley-positive-integer
           />
         );
       }
@@ -155,7 +155,7 @@ class MatrixQuestion extends TransformQuestion {
                     defaultValue="0"
                     data-output-no={survey.findOutputNoFromName(totalName)}
                     data-parsley-required
-                    data-parsley-type="digits"
+                    data-parsley-positive-integer
                     data-parsley-equal={!S(totalEqualTo).isEmpty() ? replacer.id2Value(totalEqualTo) : null}
                   />
                 </td>
@@ -193,7 +193,7 @@ class MatrixQuestion extends TransformQuestion {
             defaultValue="0"
             data-output-no={survey.findOutputNoFromName(totalName)}
             data-parsley-required
-            data-parsley-type="digits"
+            data-parsley-positive-integer
             data-parsley-equal={!S(totalEqualTo).isEmpty() ? replacer.id2Value(totalEqualTo) : null}
           />
         </td>

--- a/lib/runtime/components/questions/MultiNumberQuestion.js
+++ b/lib/runtime/components/questions/MultiNumberQuestion.js
@@ -83,10 +83,10 @@ class MultiNumberQuestion extends TransformQuestion {
               data-response-multiple
               data-response-item-index={isTotal ? null : item.getIndex()}
               data-parsley-required={!isTotal}
-              data-parsley-type="digits"
               data-parsley-min={isTotal || S(question.getMin()).isEmpty() ? null : replacer.id2Value(question.getMin())}
               data-parsley-max={isTotal || S(question.getMax()).isEmpty() ? null : replacer.id2Value(question.getMax())}
               data-parsley-equal={isTotal && !S(totalEqualTo).isEmpty() ? replacer.id2Value(totalEqualTo) : null}
+              data-parsley-positive-integer
               data-parsley-errors-container={`#${errorContainerId}`}
             />
             <span className="multiNumberUnit"> {question.getUnit()}</span>

--- a/lib/runtime/components/questions/PersonalInfoQuestion.js
+++ b/lib/runtime/components/questions/PersonalInfoQuestion.js
@@ -160,7 +160,7 @@ class PersonalInfoQuestion extends Component {
                       style={{ width: '5em' }}
                       data-output-no={this.getOutputNo(FIELDS.age)}
                       data-parsley-required
-                      data-parsley-type="digits"
+                      data-parsley-positive-integer
                     />
                   </label>
                 </td>


### PR DESCRIPTION
下記の不具合に対応

010などの数値が入力できてしまう。
回答データにも含まれる。

条件分岐の入力値に使われた場合は文字列と比較するため
10と010は別物として扱われ、条件分岐の評価がfalseになってしまう。