### PR TITLE
Hotfix/v1.7.2

### DIFF
--- a/lib/runtime/actions.js
+++ b/lib/runtime/actions.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import Raven from 'raven-js';
 import * as C from '../constants/actions';
 import { ANSWER_POSTED_SUCCESS, ANSWER_POSTED_FAILED, ANSWER_POSTING } from '../constants/states';
 
@@ -44,7 +45,8 @@ export function asyncPostAnswer(dispatch, survey, answers, isComplete, options) 
   }).done((response) => {
     dispatch(updatePostAnswerStatus(ANSWER_POSTED_SUCCESS));
     if (answerRegisteredFn) answerRegisteredFn(survey, response);
-  }).fail(() => {
+  }).fail((e) => {
+    Raven.captureException(e);
     dispatch(updatePostAnswerStatus(ANSWER_POSTED_FAILED));
   });
 }

--- a/lib/runtime/components/Page.js
+++ b/lib/runtime/components/Page.js
@@ -187,13 +187,6 @@ class Page extends Component {
             this.handleError(e);
           }
 
-          // 将来的にはこのページ遷移の処理は削除する
-          Raven.captureMessage(this.createRavenMessage('ページ遷移します'), {
-            level: 'info',
-            tags: { pageId, pageNo },
-            fingerprint: [survey.getId(), options.getUserId()], // ページIDは含まない
-          });
-
           nextPage();
           animateScroll.scrollToTop({
             smooth: true,

--- a/lib/runtime/components/Page.js
+++ b/lib/runtime/components/Page.js
@@ -1,5 +1,6 @@
 /* eslint-env browser */
 import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
 import Raven from 'raven-js';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
@@ -30,12 +31,15 @@ class Page extends Component {
 
   componentDidMount() {
     const { options, doNotTransition } = this.props;
+    const pageEl = ReactDOM.findDOMNode(this);
     this.evaluateJavaScript(this.createSurveyJS());
     this.parsley();
-    if (!options.isShowDetail() && !doNotTransition) pagePlainComponents(this.pageEl);
-    if (options.isShowOutputNo()) showOutputNo(this.pageEl);
+
     // ユーザの行動をトレースする
     $(pageEl).on('change', this.handleChange.bind(this));
+
+    if (!options.isShowDetail() && !doNotTransition) pagePlainComponents(pageEl);
+    if (options.isShowOutputNo()) showOutputNo(pageEl);
 
     this.hideQuestionIfNoInputElements();
     this.skipPageIfNoInputElements();
@@ -54,7 +58,8 @@ class Page extends Component {
 
   /** 入力値を取得する。validation済みであることを期待している */
   getAnswers() {
-    const formElements = Array.prototype.slice.call(this.pageEl.querySelectorAll('input,textarea,select'));
+    const pageEl = ReactDOM.findDOMNode(this);
+    const formElements = Array.prototype.slice.call(pageEl.querySelectorAll('input,textarea,select'));
     const answers = {};
     // ユーザの入力値
     formElements.forEach((el) => {
@@ -201,7 +206,8 @@ class Page extends Component {
 
   /** Question内に一つも設問がない場合には設問を非表示にする */
   hideQuestionIfNoInputElements() {
-    $(this.pageEl).find('.questionBox').each((index, questionBoxEl) => {
+    const pageEl = ReactDOM.findDOMNode(this);
+    $(pageEl).find('.questionBox').each((index, questionBoxEl) => {
       const $visibleElements = findEnabledFormElement(questionBoxEl);
       if ($visibleElements.length === 0) {
         $(questionBoxEl).hide();
@@ -211,7 +217,11 @@ class Page extends Component {
 
   /** 同ページに一つも設問がない場合にはスキップする */
   skipPageIfNoInputElements() {
-    const $visibleElements = findEnabledFormElement(this.pageEl);
+    const { doNotTransition } = this.props;
+    if (doNotTransition) return;
+
+    const pageEl = ReactDOM.findDOMNode(this);
+    const $visibleElements = findEnabledFormElement(pageEl);
     if ($visibleElements.length === 0) {
       const { survey, runtime, page, nextPage } = this.props;
       const pageId = page.getId();
@@ -236,7 +246,8 @@ class Page extends Component {
     if (doNotValidate) return;
     // showDetailのときはparsleyを有効にしない
     if (options.isShowDetail()) return;
-    this.$parsley = $(this.pageEl).parsley({
+    const pageEl = ReactDOM.findDOMNode(this);
+    this.$parsley = $(pageEl).parsley({
       // デフォルト値に:hiddenを加えている。非表示項目はvalidationしない
       excluded: 'input[type=button], input[type=submit], input[type=reset], input[type=hidden], :hidden, :disabled',
       // parsley.jsのデフォルトgetValueではmultipleのvalidation時に非表示の値も取得してしまうため値の取得ロジックを変更
@@ -296,7 +307,8 @@ class Page extends Component {
     this.pageManager.init();
     if (S(javaScriptCode).isEmpty()) return;
 
-    const ownerDoc = this.pageEl.ownerDocument;
+    const pageEl = ReactDOM.findDOMNode(this);
+    const ownerDoc = pageEl.ownerDocument;
 
     try {
       new Function('$', 'document', 'SurveyJS', javaScriptCode)($, ownerDoc, SurveyJS);
@@ -352,7 +364,7 @@ class Page extends Component {
 
   render() {
     return (
-      <form ref={(el) => { this.pageEl = el || this.pageEl; }} className="page questionsBox" data-parsley-excluded="[disabled=disabled]" onSubmit={e => this.handleSubmit(e)}>
+      <form className="page questionsBox" data-parsley-excluded="[disabled=disabled]" onSubmit={e => this.handleSubmit(e)}>
         { this.createQuestions() }
         { this.createPageDetail() }
         { this.createButtons() }

--- a/lib/runtime/components/Page.js
+++ b/lib/runtime/components/Page.js
@@ -34,9 +34,22 @@ class Page extends Component {
     this.parsley();
     if (!options.isShowDetail() && !doNotTransition) pagePlainComponents(this.pageEl);
     if (options.isShowOutputNo()) showOutputNo(this.pageEl);
+    // ユーザの行動をトレースする
+    $(pageEl).on('change', this.handleChange.bind(this));
 
     this.hideQuestionIfNoInputElements();
     this.skipPageIfNoInputElements();
+  }
+
+  createRavenMessage(message) {
+    const { survey, options, page } = this.props;
+    const pageNo = survey.calcPageNo(page.getId());
+    return `${message}`;
+  }
+
+  createRavenFingerPrint(message) {
+    const { survey, options, page } = this.props;
+    return [survey.getId(), options.getUserId(), page.getId()];
   }
 
   /** 入力値を取得する。validation済みであることを期待している */
@@ -76,6 +89,29 @@ class Page extends Component {
         answers[el.name] = el.value;
       }
     });
+    const { survey, options, runtime, page } = this.props;
+    // 回答データが登録されず、なおかつ説明文がQuestionにない場合にエラーとする
+    // まずはエラーログだけを取得する
+    const pageId = page.getId();
+    const pageNo = survey.calcPageNo(pageId);
+    if (Object.keys(answers).length === 0 && !page.getQuestions().find(q => q.getDataType() === 'Description')) {
+      const pageHtml = pageEl ? pageEl.innerHTML : null;
+      Raven.captureMessage(this.createRavenMessage('ページ内の回答データを取得できませんでした'), {
+        level: 'error',
+        tags: { pageId, pageNo },
+        fingerprint: this.createRavenFingerPrint(),
+        extra: {
+          formElementNumber: formElements.length,
+          pageHtml,
+          answers: runtime.getAnswers().toJS(),
+        },
+      });
+    }
+    Raven.captureMessage(this.createRavenMessage('ページ遷移します'), {
+      level: 'info',
+      tags: { pageId, pageNo },
+      fingerprint: [survey.getId(), options.getUserId()], // ページIDは含まない
+    });
     return answers;
   }
 
@@ -97,6 +133,19 @@ class Page extends Component {
 
   handleSubmit(e) {
     e.preventDefault();
+  }
+
+  handleChange(e) {
+    // 回答データをあとで取得できるように全てのchangeイベントをBreadcrumbに記録する。
+    const $target = $(e.target);
+    const name = $target.attr('name');
+    const value = $target.attr('type') === 'checkbox' ? $target.prop('checked') : $target.val();
+    const outputNo = $target.data('output-no');
+    Raven.captureBreadcrumb({
+      message: '入力値が変更されました',
+      category: 'change',
+      data: { name, value, outputNo },
+    });
   }
 
   handleClickNext() {
@@ -164,7 +213,21 @@ class Page extends Component {
   skipPageIfNoInputElements() {
     const $visibleElements = findEnabledFormElement(this.pageEl);
     if ($visibleElements.length === 0) {
-      this.handleClickNext();
+      const { survey, runtime, page, nextPage } = this.props;
+      const pageId = page.getId();
+      const pageNo = survey.calcPageNo(pageId);
+      const pageHtml = pageEl ? pageEl.innerHTML : null;
+      Raven.captureMessage(this.createRavenMessage('ページ内に入力要素がないためページをスキップします'), {
+        level: 'warning',
+        tags: { pageId, pageNo },
+        fingerprint: this.createRavenFingerPrint(),
+        extra: {
+          pageHtml,
+          answers: runtime.getAnswers().toJS(),
+        },
+      });
+
+      nextPage();
     }
   }
 

--- a/lib/runtime/components/Page.js
+++ b/lib/runtime/components/Page.js
@@ -95,28 +95,6 @@ class Page extends Component {
       }
     });
     const { survey, options, runtime, page } = this.props;
-    // 回答データが登録されず、なおかつ説明文がQuestionにない場合にエラーとする
-    // まずはエラーログだけを取得する
-    const pageId = page.getId();
-    const pageNo = survey.calcPageNo(pageId);
-    if (Object.keys(answers).length === 0 && !page.getQuestions().find(q => q.getDataType() === 'Description')) {
-      const pageHtml = pageEl ? pageEl.innerHTML : null;
-      Raven.captureMessage(this.createRavenMessage('ページ内の回答データを取得できませんでした'), {
-        level: 'error',
-        tags: { pageId, pageNo },
-        fingerprint: this.createRavenFingerPrint(),
-        extra: {
-          formElementNumber: formElements.length,
-          pageHtml,
-          answers: runtime.getAnswers().toJS(),
-        },
-      });
-    }
-    Raven.captureMessage(this.createRavenMessage('ページ遷移します'), {
-      level: 'info',
-      tags: { pageId, pageNo },
-      fingerprint: [survey.getId(), options.getUserId()], // ページIDは含まない
-    });
     return answers;
   }
 
@@ -154,7 +132,7 @@ class Page extends Component {
   }
 
   handleClickNext() {
-    const { runtime, survey, surveyManager, page, nextPage, changeAnswers, doNotTransition } = this.props;
+    const { runtime, survey, options, surveyManager, page, nextPage, changeAnswers, doNotTransition } = this.props;
 
     // doNotTransitionが指定されていたらなにも実行しない
     if (doNotTransition) return;
@@ -162,9 +140,28 @@ class Page extends Component {
     // validationに失敗したら次のページに行かない
     if (!this.$parsley.validate()) return;
 
+    const pageEl = ReactDOM.findDOMNode(this);
     const answers = runtime.getAnswers().toJS();
     // namesに対応する値を取得
     const pageAnswers = this.getAnswers();
+
+    // 回答データが登録されず、なおかつ説明文がQuestionにない場合にエラーとする
+    // まずはエラーログだけを取得する
+    const pageId = page.getId();
+    const pageNo = survey.calcPageNo(pageId);
+    if (Object.keys(pageAnswers).length === 0 && !page.getQuestions().find(q => q.getDataType() === 'Description')) {
+      const pageHtml = pageEl ? pageEl.innerHTML : null;
+      Raven.captureMessage(this.createRavenMessage('ページ内の回答データを取得できませんでした'), {
+        level: 'error',
+        tags: { pageId, pageNo },
+        fingerprint: this.createRavenFingerPrint(),
+        extra: {
+          pageHtml,
+          answers: runtime.getAnswers().toJS(),
+        },
+      });
+    }
+
     const mergedAnswers = Object.assign({}, answers, pageAnswers);
     surveyManager.refresh(mergedAnswers);
     this.pageManager.fireValidate(survey, page, mergedAnswers)
@@ -189,6 +186,13 @@ class Page extends Component {
           } catch (e) {
             this.handleError(e);
           }
+
+          // 将来的にはこのページ遷移の処理は削除する
+          Raven.captureMessage(this.createRavenMessage('ページ遷移します'), {
+            level: 'info',
+            tags: { pageId, pageNo },
+            fingerprint: [survey.getId(), options.getUserId()], // ページIDは含まない
+          });
 
           nextPage();
           animateScroll.scrollToTop({

--- a/lib/runtime/models/options/Options.js
+++ b/lib/runtime/models/options/Options.js
@@ -21,6 +21,7 @@ export const OptionsRecord = Record({
   answerRegisteredFn: null,                // 回答を登録したときに実行するコールバック関数
   pageLoadedFn: null,                      // ページ遷移したときに呼ばれるコールバック関数
   exposeSurveyJS: false,                   // SurveyJSをwindowに紐つけるかどうか。trueの場合はSurveyJSという名前で設定する。文字列の場合は指定した文字列の名前で設定する。
+  userId: null,                            // 回答者のユーザID
 });
 
 export default class Options extends OptionsRecord {
@@ -103,5 +104,9 @@ export default class Options extends OptionsRecord {
 
   isExposeSurveyJS() {
     return this.get('exposeSurveyJS');
+  }
+
+  getUserId() {
+    return this.get('userId');
   }
 }

--- a/lib/runtime/reducers.js
+++ b/lib/runtime/reducers.js
@@ -1,3 +1,4 @@
+import Raven from 'raven-js';
 import * as C from '../constants/actions';
 
 export default function reducer(state, action) {
@@ -25,6 +26,7 @@ export default function reducer(state, action) {
         });
     }
   } catch (e) {
+    Raven.captureException(e);
     console.error(e);
     alert(e);
     return state;


### PR DESCRIPTION
# 概要
IE9, 11で回答中にデータが欠損してしまう不具合が発生。
原因は特定できたわけではないが、怪しい箇所の変更とリカバリできるようログ出力を加える。

# 対応方法

- 怪しい箇所の変更
    - Page.jsのthis.pageElをrefから取得するのではなく、ReactDOM.findDOMNodeを使用するように変更
 - リカバリできるようにログ出力
    - Sentryに各種ログを送付する

  |   | 登録するデータ |   |  
-- | -- | -- | -- | --
タイミング | ログタイプ | ページに含まれるHTML | それまでの全回答データ(answers) | 要素の変更イベント
回答データをページの要素から取得するときににデータがない場合 | error | ◯ | ◯ | ◯
ページスキップした場合 | warning |   | ◯ | ◯
次へボタンをおした時 | info |   |   | ◯

